### PR TITLE
Configurable path for config.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ ENV IMPORT_DIR=/import \
     IMPOSM_CACHE_DIR=/cache \
     MAPPING_YAML=/mapping/mapping.yaml \
     DIFF_DIR=/import \
-    TILES_DIR=/import
+    TILES_DIR=/import \
+    CONFIG_JSON=config.json
 
 WORKDIR /usr/src/app
 COPY . /usr/src/app/

--- a/import_diff.sh
+++ b/import_diff.sh
@@ -13,7 +13,7 @@ function import_diff() {
         -diffdir "$IMPORT_DIR" \
         -expiretiles-dir "$IMPORT_DIR" \
         -expiretiles-zoom 14 \
-        -config config.json "$IMPORT_DIR/changes.osc.gz"
+        -config $CONFIG_JSON "$IMPORT_DIR/changes.osc.gz"
 }
 
 import_diff

--- a/import_update.sh
+++ b/import_update.sh
@@ -13,7 +13,7 @@ function update() {
         -diffdir "$DIFF_DIR" \
         -expiretiles-dir "$TILES_DIR" \
         -expiretiles-zoom 14 \
-        -config config.json
+        -config $CONFIG_JSON
 }
 
 update


### PR DESCRIPTION
Default `config.json` uses OSM URL for an update process.

The utility `imposm3` is firstly finding path for updates in `config.json`, and then in the `last.state.txt` file.

This could simplify process for updating using `imposm3` and different server than OSM (for example geofabrik.de extracts server).