### PR TITLE
Use download-geofabrik generate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
  # add  github.com/julien-noblet/download-geofabrik
 RUN go get github.com/julien-noblet/download-geofabrik \
  && go install  github.com/julien-noblet/download-geofabrik \
- && download-geofabrik update \
+ && download-geofabrik generate \
  # add  github.com/lukasmartinelli/pgclimb
  && go get github.com/lukasmartinelli/pgclimb \
  && go install github.com/lukasmartinelli/pgclimb \

--- a/download-geofabrik-list.sh
+++ b/download-geofabrik-list.sh
@@ -4,6 +4,6 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-download-geofabrik update
+download-geofabrik generate
 download-geofabrik list
 

--- a/download-geofabrik.sh
+++ b/download-geofabrik.sh
@@ -18,7 +18,7 @@ rm -f *.mbtiles
 rm -f *.txt
 rm -f *.yml
 
-download-geofabrik update
+download-geofabrik generate
 download-geofabrik -v download $AREA
  
 ls *.osm.pbf  -la


### PR DESCRIPTION
Since ```download-geofabrik update``` is deprecated,
you should use ```generate``` it will create a new geofabrik.yml by parsing download.geofabrik.de :smile:

At home, It take less than a minute.