### PR TITLE
Download PBF with state file, for update usage

### DIFF
--- a/download-geofabrik.sh
+++ b/download-geofabrik.sh
@@ -20,7 +20,10 @@ rm -f *.yml
 
 download-geofabrik update
 download-geofabrik -v download $AREA
- 
+download-geofabrik -s download $AREA
+
+mv ${AREA}.state last.state.txt
+
 ls *.osm.pbf  -la
 osmconvert  --out-statistics  ${AREA}.osm.pbf  > ./osmstat.txt
 


### PR DESCRIPTION
imposm update needs `last.state.txt` in path as `-diffdir`, which is used in `import_update.sh`
https://github.com/openmaptiles/import-osm/blob/68a6c8373363bc68c989fe1507121e6ca03cf5a2/import_update.sh#L13

So we should also download state file after getting PBF file